### PR TITLE
Make discovering mitogen location less manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ _This is now using *Python 3*._
 
 To leverage *Mitogen* to accelerate your playbook runs, add this to your ```ansible.cfg```:
 
-@TODO This needs updating, please investigate in your container the location of `ansible_mitogen`.
+Please investigate in your container the location of `ansible_mitogen` (it is different per container). You can do this via:
+
+```bash
+your_container="ansible:2.9-ubuntu"
+docker run --rm -it "willhallonline/${your_container}" /bin/sh -c "find / -type d | grep "ansible_mitogen/plugins" | sort | head -n 1"
+```
+
+and then configuring your own ansible.cfg like:
 
 ```ini
 [defaults]


### PR DESCRIPTION
I think this could be done a couple different ways too, but there are drawbacks so I didn't try them:

1. via an `entrypoint` script to wrap `ansible-playbook`, where that particular configuration key can be done via `ANSIBLE_STRATEGY_PLUGINS="$(find / -type d | grep "ansible_mitogen/plugins" | sort | head -n 1)"` ahead of running the `ansible-playbook ${@}` command
    * ... but that introduces overhead on every invoke, clearly
    * ... and it means that people who manage Windows machines would need a way to disable it (I think)
1. via using a python venv + requirements.txt in every container to nail down the path precisely across all containers - but I'm not sufficiently python-y to knock that out quickly