### PR TITLE
add collections path env for ubuntu 24.04

### DIFF
--- a/ansible-core/ubuntu2404/Dockerfile
+++ b/ansible-core/ubuntu2404/Dockerfile
@@ -7,6 +7,7 @@ ENV ANSIBLE_CORE_VERSION ${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION ${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT ${ANSIBLE_LINT}
 ENV PIPX_BIN_DIR=/usr/local/bin
+ENV ANSIBLE_COLLECTIONS_PATHS=/root/.local/share/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \


### PR DESCRIPTION
Since Ubuntu 24 image pipx is used instead of pip to install Ansible, which causes that the Ansible Collections are not saved to the default path anymore.