### PR TITLE
Fix deprecated variable

### DIFF
--- a/ansible-core/ubuntu2404/Dockerfile
+++ b/ansible-core/ubuntu2404/Dockerfile
@@ -7,7 +7,7 @@ ENV ANSIBLE_CORE_VERSION ${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION ${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT ${ANSIBLE_LINT}
 ENV PIPX_BIN_DIR=/usr/local/bin
-ENV ANSIBLE_COLLECTIONS_PATHS=/root/.local/share/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
+ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \


### PR DESCRIPTION
[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option. Reason: does not fit var naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead Alternatives: none. This feature
will be removed in version 2.19. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.