### PR TITLE
Ansible220

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ env:
   ANSIBLE_CORE_217: 2.17.14
   ANSIBLE_CORE_218: 2.18.9
   ANSIBLE_CORE_219: 2.19.2
+  ANSIBLE_CORE_220: 2.20.0
   ANSIBLE_LINT_213: 5.4.0
   ANSIBLE_LINT_214: 6.20.3
   ANSIBLE_LINT_215: 6.20.3
@@ -36,6 +37,7 @@ env:
   ANSIBLE_LINT_217: 25.4.0
   ANSIBLE_LINT_218: 25.9.0
   ANSIBLE_LINT_219: 25.9.0
+  ANSIBLE_LINT_220: 25.9.0
   ANSIBLE_213: 6.7.0
   ANSIBLE_214: 7.7.0
   ANSIBLE_215: 8.7.0
@@ -43,6 +45,7 @@ env:
   ANSIBLE_217: 10.7.0
   ANSIBLE_218: 11.10.0
   ANSIBLE_219: 12.0.0
+  ANSIBLE_220: 13.0.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -88,6 +91,9 @@ jobs:
           - os: alpine-3.20
             ansible-version: '219'
             tag-version: 2.19
+          - os: alpine-3.20
+            ansible-version: '220'
+            tag-version: 2.20
 
           # Alpine 3.21
           - os: alpine-3.21
@@ -102,6 +108,9 @@ jobs:
           - os: alpine-3.21
             ansible-version: '219'
             tag-version: 2.19
+          - os: alpine-3.21
+            ansible-version: '220'
+            tag-version: 2.20
 
           # Alpine 3.22
           - os: alpine-3.22
@@ -116,6 +125,9 @@ jobs:
           - os: alpine-3.22
             ansible-version: '219'
             tag-version: 2.19
+          - os: alpine-3.22
+            ansible-version: '220'
+            tag-version: 2.20
 
           # Debian bookworm
           - os: debian-bookworm
@@ -155,6 +167,9 @@ jobs:
           - os: debian-trixie
             ansible-version: '219'
             tag-version: 2.19
+          - os: debian-trixie
+            ansible-version: '220'
+            tag-version: 2.20
 
           # Debian Trixie Slim
           - os: debian-trixie-slim
@@ -166,6 +181,9 @@ jobs:
           - os: debian-trixie-slim
             ansible-version: '219'
             tag-version: 2.19
+          - os: debian-trixie-slim
+            ansible-version: '220'
+            tag-version: 2.20
 
           # Rocky Linux 10
           - os: rockylinux-10
@@ -180,6 +198,9 @@ jobs:
           - os: rockylinux-10
             ansible-version: '219'
             tag-version: 2.19
+          - os: rockylinux-10
+            ansible-version: '220'
+            tag-version: 2.20
 
           # Ubuntu-22.04
           - os: ubuntu-22.04
@@ -202,6 +223,9 @@ jobs:
           - os: ubuntu-24.04
             ansible-version: '219'
             tag-version: 2.19
+          - os: ubuntu-24.04
+            ansible-version: '220'
+            tag-version: 2.20
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v6.3.0
+
+* Included Ansible 2.20.0 for:
+  - Alpine 3.20, 3.21, and 3.22
+  - Debian Trixie and Debian Trixie Slim
+  - Rocky Linux 10
+  - Ubuntu 24.04
+
 ## v6.2.3
 
 - Fix Docker Pull documentation in README

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These are the latest Ansible Core versions running within the containers:
 - Ansible 2.17: 2.17.14
 - Ansible 2.18: 2.18.9
 - Ansible 2.19: 2.19.2
+- Ansible 2.20: 2.20.0
 - Older versions are provided within the unmaintained section, including 2.9, 2.10, 2.11, 2.12, 2.13, 2.14 and 2.15.
 - More availablity on Ansible versions on [Ansible Release Documentation](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html) and [Ansible-core to Python compatibility](https://pypi.org/project/ansible-core/#history).
 
@@ -22,7 +23,7 @@ These are the latest Ansible Core versions running within the containers:
 
 There are a number of immutable images that are also being collected. To find a specific version of Ansible, look within the [Docker Hub Tags](https://hub.docker.com/r/willhallonline/ansible/tags). Each of the containers follow a similar pattern: **Ansible-version**-**Base OS version**.
 
-### Ansible Core (2.16, 2.17, 2.18, 2.19)
+### Ansible Core (2.16, 2.17, 2.18, 2.19, 2.20)
 
 This includes:
 
@@ -32,22 +33,22 @@ This includes:
 
 ARM releases should now be available for each container image! This happened in the migration to GitHub Actions, but I forgot to update this line.
 
-| Base Image (↓) \ Ansible Version (→) | Dockerfile                                                                                                            | 2.19                        | 2.18                        | 2.17                        | 2.16                        |
-|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------|-----------------------------|-----------------------------|-----------------------------|
-| Latest                               | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.22/Dockerfile)          | `latest`                    |                             |                             |                             |
-| Alpine                               | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.22/Dockerfile)          | `alpine`                    |                             |                             |                             |
-| Ubuntu                               | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/ubuntu-24.04/Dockerfile)         | `ubuntu`                    |                             |                             |                             |
-| Alpine 3.19                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.19/Dockerfile)          | `2.19-alpine-3.19`          | `2.18-alpine-3.19`          | `2.17-alpine-3.19`          | `2.16-alpine-3.19`          |
-| Alpine 3.20                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.20/Dockerfile)          | `2.19-alpine-3.20`          | `2.18-alpine-3.20`          | `2.17-alpine-3.20`          | `2.16-alpine-3.20`          |
-| Alpine 3.21                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.21/Dockerfile)          | `2.19-alpine-3.21`          | `2.18-alpine-3.21`          | `2.17-alpine-3.21`          | `2.16-alpine-3.21`          |
-| Alpine 3.22                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.22/Dockerfile)          | `2.19-alpine-3.22`          | `2.18-alpine-3.22`          | `2.17-alpine-3.22`          | `2.16-alpine-3.22`          |
-| Bookworm (Debian 12)                 | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-bookworm/Dockerfile)      | `2.19-debian-bookworm`      | `2.18-debian-bookworm`      | `2.17-debian-bookworm`      | `2.16-debian-bookworm`      |
-| Bookworm Slim (Debian 12)            | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-bookworm-slim/Dockerfile) | `2.19-debian-bookworm-slim` | `2.18-debian-bookworm-slim` | `2.17-debian-bookworm-slim` | `2.16-debian-bookworm-slim` |
-| Trixie (Debian 13)                   | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-trixie/Dockerfile)        | `2.19-debian-trixie`        | `2.18-debian-trixie`        | `2.17-debian-trixie`        |                             |
-| Trixie Slim (Debian 13)              | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-trixie-slim/Dockerfile)   | `2.19-debian-trixie-slim`   | `2.18-debian-trixie-slim`   | `2.17-debian-trixie-slim`   |                             |
-| Rocky Linux 10                       | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/rockylinux-10/Dockerfile)        | `2.19-rockylinux-10`        | `2.18-rockylinux-10`        | `2.17-rockylinux-10`        | `2.16-rockylinux-10`        |
-| Ubuntu 22.04                         | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/ubuntu-22.04/Dockerfile)         |                             |                             | `2.17-ubuntu-22.04`         | `2.16-ubuntu-22.04`         |
-| Ubuntu 24.04                         | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/ubuntu-24.04/Dockerfile)         | `2.19-ubuntu-24.04`         | `2.18-ubuntu-24.04`         | `2.17-ubuntu-24.04`         | `2.16-ubuntu-24.04`         |
+| Base Image (↓) \ Ansible Version (→) | Dockerfile                                                                                                            | 2.20                      | 2.19                        | 2.18                        | 2.17                        | 2.16                        |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------|---------------------------|-----------------------------|-----------------------------|-----------------------------|-----------------------------|
+| Latest                               | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.22/Dockerfile)          |                           | `latest`                    |                             |                             |                             |
+| Alpine                               | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.22/Dockerfile)          |                           | `alpine`                    |                             |                             |                             |
+| Ubuntu                               | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/ubuntu-24.04/Dockerfile)         |                           | `ubuntu`                    |                             |                             |                             |
+| Alpine 3.19                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.19/Dockerfile)          |                           | `2.19-alpine-3.19`          | `2.18-alpine-3.19`          | `2.17-alpine-3.19`          | `2.16-alpine-3.19`          |
+| Alpine 3.20                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.20/Dockerfile)          | `2.20-alpine-3.20`        | `2.19-alpine-3.20`          | `2.18-alpine-3.20`          | `2.17-alpine-3.20`          | `2.16-alpine-3.20`          |
+| Alpine 3.21                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.21/Dockerfile)          | `2.20-alpine-3.21`        | `2.19-alpine-3.21`          | `2.18-alpine-3.21`          | `2.17-alpine-3.21`          | `2.16-alpine-3.21`          |
+| Alpine 3.22                          | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/alpine-3.22/Dockerfile)          | `2.20-alpine-3.22`        | `2.19-alpine-3.22`          | `2.18-alpine-3.22`          | `2.17-alpine-3.22`          | `2.16-alpine-3.22`          |
+| Bookworm (Debian 12)                 | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-bookworm/Dockerfile)      |                           | `2.19-debian-bookworm`      | `2.18-debian-bookworm`      | `2.17-debian-bookworm`      | `2.16-debian-bookworm`      |
+| Bookworm Slim (Debian 12)            | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-bookworm-slim/Dockerfile) |                           | `2.19-debian-bookworm-slim` | `2.18-debian-bookworm-slim` | `2.17-debian-bookworm-slim` | `2.16-debian-bookworm-slim` |
+| Trixie (Debian 13)                   | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-trixie/Dockerfile)        | `2.20-debian-trixie`      | `2.19-debian-trixie`        | `2.18-debian-trixie`        | `2.17-debian-trixie`        |                             |
+| Trixie Slim (Debian 13)              | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/debian-trixie-slim/Dockerfile)   | `2.20-debian-trixie-slim` | `2.19-debian-trixie-slim`   | `2.18-debian-trixie-slim`   | `2.17-debian-trixie-slim`   |                             |
+| Rocky Linux 10                       | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/rockylinux-10/Dockerfile)        | `2.20-rockylinux-10`      | `2.19-rockylinux-10`        | `2.18-rockylinux-10`        | `2.17-rockylinux-10`        | `2.16-rockylinux-10`        |
+| Ubuntu 22.04                         | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/ubuntu-22.04/Dockerfile)         |                           |                             |                             | `2.17-ubuntu-22.04`         | `2.16-ubuntu-22.04`         |
+| Ubuntu 24.04                         | [Dockerfile](https://github.com/willhallonline/docker-ansible/blob/main/ansible-core/ubuntu-24.04/Dockerfile)         | `2.20-ubuntu-24.04`       | `2.19-ubuntu-24.04`         | `2.18-ubuntu-24.04`         | `2.17-ubuntu-24.04`         | `2.16-ubuntu-24.04`         |
 
 ### Older versions (2.9, 2.10, 2.11, 2.12, 2.13, 2.14, 2.15)
 


### PR DESCRIPTION
<!-- 
Thank you for contributing to the docker-ansible project!
Please fill out the details below to help maintainers review your pull request effectively.
-->

## Description

This pull request updates the GitHub Actions workflow in `.github/workflows/build.yml` to add support for Ansible 2.20.0 and related tooling across all tested operating system environments. The main goal is to ensure the build matrix tests the latest Ansible release for compatibility.

**Build matrix expansion:**

* Added new environment variables for `ANSIBLE_CORE_220`, `ANSIBLE_LINT_220`, and `ANSIBLE_220` to support Ansible 2.20.0 and its associated lint and core versions.
* Included Ansible 2.20.0 for:
  - Alpine 3.20, 3.21, and 3.22
  - Debian Trixie and Debian Trixie Slim
  - Rocky Linux 10
  - Ubuntu 24.04

---

## Related Issues/Tickets (if any)

- Fixes #144 - Asking for Ansible-core 2.20

---

## Type of Change

Choose the type of change(s) included in this pull request (mark with an `X`):

- [ ] Bug Fix
- [x] New Feature
- [x] Documentation Update
- [ ] Refactor/Code Cleanup
- [ ] Other (please specify):

---

## Checklist

Please confirm the following (mark with an `X`):

- [x] I have tested my changes and ensured everything works as expected.
- [x] I have updated the documentation (if applicable).
- [x] I have checked for any breaking changes and updated the relevant files accordingly.
- [x] I have run any relevant tests and confirmed that they pass.
- [x] I have added a detailed description of my changes and any related issues.

