### PR TITLE
fix collection path on ubuntu 26.04

### DIFF
--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -7,7 +7,7 @@ ENV ANSIBLE_CORE_VERSION=${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT=${ANSIBLE_LINT}
 ENV PIPX_BIN_DIR=/usr/local/bin
-ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
+ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.14/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \


### PR DESCRIPTION
## Description

On Ubuntu 26.04 the ansible collection path variable is wrong due to new python version number. This change will update to the correct path.

---

## Type of Change

Choose the type of change(s) included in this pull request (mark with an `X`):

- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Refactor/Code Cleanup
- [ ] Other (please specify):

---

## Checklist

Please confirm the following (mark with an `X`):

- [x] I have tested my changes and ensured everything works as expected.
- [ ] I have updated the documentation (if applicable).
- [x] I have checked for any breaking changes and updated the relevant files accordingly.
- [x] I have run any relevant tests and confirmed that they pass.
- [x] I have added a detailed description of my changes and any related issues.

---

## Testing Steps

If applicable, provide the testing steps to verify your changes:

1. build the container
2. run a script which requires the correct path. e.g. ansible.posix.synchronize module