### PR TITLE
Update QEMU binfmt to v9.2.2 to fix Python 3.13 arm64 build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:
-          image: tonistiigi/binfmt:qemu-v7.0.0
+          image: tonistiigi/binfmt:qemu-v9.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## Problem

The scheduled Ansible Matrix Build on `main` has failed for 4 consecutive weeks (runs on Jun 22, Jun 29, Jul 6, Jul 13). Each time, only the `ansible:2.18-debian-trixie` and `ansible:2.21-debian-trixie` jobs fail, during the **arm64** (QEMU-emulated) stage of `docker buildx`:

```
Exception: ('python3.13', '-c', 'import sys; print(sys.implementation.cache_tag)') failed with status code -11
dpkg: error processing package python3-minimal (--configure)
```

Python 3.13 (shipped in Debian trixie) segfaults under QEMU v7.0.0, which the workflow pins via `tonistiigi/binfmt:qemu-v7.0.0`. This is a known QEMU incompatibility fixed in newer QEMU releases.

## Fix

Bump the pinned binfmt image to `tonistiigi/binfmt:qemu-v9.2.2`.

## Verification

Installed `binfmt:qemu-v9.2.2` locally and ran the exact failing invocation in an arm64 trixie container:

```
$ docker run --rm --platform linux/arm64 python:3.13-slim-trixie \
    python3 -c "import sys; print(sys.implementation.cache_tag)"
cpython-313
```

No segfault. ✅