### PR TITLE
Add changelog entry for version 6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v6.4.2
+
+- Fix scheduled matrix build failures on `debian-trixie` arm64 builds by updating QEMU binfmt to v9.2.2 (Python 3.13 segfaulted under QEMU v7.0.0) #170
+- Bump actions/checkout from 6 to 7 #167
+- Bump docker/metadata-action from 6.1.0 to 6.2.0 #168
+- Bump docker/build-push-action from 7.2.0 to 7.3.0 #169
+
 ## v6.4.1
 
 - Fix collection paths for Ubuntu 26.04 #166


### PR DESCRIPTION
Adds the v6.4.2 changelog entry covering:

- QEMU binfmt v9.2.2 update fixing debian-trixie arm64 matrix build failures (#170)
- Dependabot bumps: actions/checkout v7 (#167), docker/metadata-action 6.2.0 (#168), docker/build-push-action 7.3.0 (#169)

A v6.4.2 tag/release will follow once merged.