### PR TITLE
Add HEALTHCHECK instruction to all active Dockerfiles

### DIFF
--- a/ansible-core/alpine-3.19/Dockerfile
+++ b/ansible-core/alpine-3.19/Dockerfile
@@ -53,4 +53,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/alpine-3.20/Dockerfile
+++ b/ansible-core/alpine-3.20/Dockerfile
@@ -53,4 +53,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/alpine-3.21/Dockerfile
+++ b/ansible-core/alpine-3.21/Dockerfile
@@ -53,4 +53,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/alpine-3.22/Dockerfile
+++ b/ansible-core/alpine-3.22/Dockerfile
@@ -53,4 +53,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-bookworm-slim/Dockerfile
+++ b/ansible-core/debian-bookworm-slim/Dockerfile
@@ -37,4 +37,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-bookworm/Dockerfile
+++ b/ansible-core/debian-bookworm/Dockerfile
@@ -37,4 +37,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-trixie-slim/Dockerfile
+++ b/ansible-core/debian-trixie-slim/Dockerfile
@@ -43,4 +43,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-trixie/Dockerfile
+++ b/ansible-core/debian-trixie/Dockerfile
@@ -38,4 +38,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/rockylinux-10/Dockerfile
+++ b/ansible-core/rockylinux-10/Dockerfile
@@ -38,4 +38,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/ubuntu-22.04/Dockerfile
+++ b/ansible-core/ubuntu-22.04/Dockerfile
@@ -36,4 +36,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/ubuntu-24.04/Dockerfile
+++ b/ansible-core/ubuntu-24.04/Dockerfile
@@ -40,4 +40,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -40,4 +40,7 @@ RUN mkdir /ansible && \
 
 WORKDIR /ansible
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD [ "ansible", "--version" ]
+
 CMD [ "ansible-playbook", "--version" ]


### PR DESCRIPTION
Closes #165

## What

Adds a `HEALTHCHECK` instruction to all 12 active `ansible-core` Dockerfile variants, placed just before the `CMD` instruction:

```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
    CMD [ "ansible", "--version" ]
```

## Why

Container orchestrators (Docker Compose, Kubernetes, Swarm) can now verify container health. Running `ansible --version` confirms the Ansible installation and Python runtime are functional.

## Notes

- Archived Dockerfiles under `archive/` were intentionally left untouched.
- Validated all 12 Dockerfiles with `docker build --check` — no new warnings introduced (only the pre-existing `$BUILD_DATE`/`$VCS_REF` undefined-var warnings remain).