### PR TITLE
Move from pip/pipx to uv for Python package installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Move from `pip`/`pipx` to [`uv`](https://github.com/astral-sh/uv) for installing Ansible and Python dependencies across all images #143
+  - Packages are installed into the system Python (no virtualenv), so everything remains available to the root user
+  - `uv` is included in the images (`uv` and `uvx` on the `PATH`) for installing additional Python packages
+  - Ubuntu 24.04 and 26.04 no longer use `pipx`; the `ANSIBLE_COLLECTIONS_PATH` and `PIPX_BIN_DIR` environment variables have been removed as collections are now discovered from the system site-packages
+
 ## v6.4.2
 
 - Fix scheduled matrix build failures on `debian-trixie` arm64 builds by updating QEMU binfmt to v9.2.2 (Python 3.13 segfaulted under QEMU v7.0.0) #170

--- a/ansible-core/alpine-3.19/Dockerfile
+++ b/ansible-core/alpine-3.19/Dockerfile
@@ -1,6 +1,8 @@
 # pull base image
 FROM alpine:3.19
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -22,8 +24,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
 
 RUN apk --no-cache add \
         sudo \
-        python3\
-        py3-pip \
+        python3 \
         openssl \
         ca-certificates \
         sshpass \
@@ -37,14 +38,11 @@ RUN apk --no-cache add \
         gcc \
         cargo \
         build-base && \
-    find /usr/lib/python* -name "EXTERNALLY-MANAGED" -exec rm {} \; && \
-    pip3 install --upgrade pip wheel && \
-    pip3 install --upgrade cryptography cffi pywinrm && \
-    pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pip3 install mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade cryptography cffi pywinrm && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
     apk del build-dependencies && \
     rm -rf /var/cache/apk/* && \
-    rm -rf /root/.cache/pip && \
     rm -rf /root/.cargo
 
 RUN mkdir /ansible && \

--- a/ansible-core/alpine-3.20/Dockerfile
+++ b/ansible-core/alpine-3.20/Dockerfile
@@ -1,6 +1,8 @@
 # pull base image
 FROM alpine:3.20
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -22,8 +24,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
 
 RUN apk --no-cache add \
         sudo \
-        python3\
-        py3-pip \
+        python3 \
         openssl \
         ca-certificates \
         sshpass \
@@ -37,14 +38,11 @@ RUN apk --no-cache add \
         gcc \
         cargo \
         build-base && \
-    find /usr/lib/python* -name "EXTERNALLY-MANAGED" -exec rm {} \; && \
-    pip3 install --upgrade pip wheel && \
-    pip3 install --upgrade cryptography cffi pywinrm && \
-    pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pip3 install mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade cryptography cffi pywinrm && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
     apk del build-dependencies && \
     rm -rf /var/cache/apk/* && \
-    rm -rf /root/.cache/pip && \
     rm -rf /root/.cargo
 
 RUN mkdir /ansible && \

--- a/ansible-core/alpine-3.21/Dockerfile
+++ b/ansible-core/alpine-3.21/Dockerfile
@@ -1,6 +1,8 @@
 # pull base image
 FROM alpine:3.21
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -22,8 +24,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
 
 RUN apk --no-cache add \
         sudo \
-        python3\
-        py3-pip \
+        python3 \
         openssl \
         ca-certificates \
         sshpass \
@@ -37,14 +38,11 @@ RUN apk --no-cache add \
         gcc \
         cargo \
         build-base && \
-    find /usr/lib/python* -name "EXTERNALLY-MANAGED" -exec rm {} \; && \
-    pip3 install --upgrade pip wheel && \
-    pip3 install --upgrade cryptography cffi pywinrm && \
-    pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pip3 install mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade cryptography cffi pywinrm && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
     apk del build-dependencies && \
     rm -rf /var/cache/apk/* && \
-    rm -rf /root/.cache/pip && \
     rm -rf /root/.cargo
 
 RUN mkdir /ansible && \

--- a/ansible-core/alpine-3.22/Dockerfile
+++ b/ansible-core/alpine-3.22/Dockerfile
@@ -1,6 +1,8 @@
 # pull base image
 FROM alpine:3.22
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -22,8 +24,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
 
 RUN apk --no-cache add \
         sudo \
-        python3\
-        py3-pip \
+        python3 \
         openssl \
         ca-certificates \
         sshpass \
@@ -37,14 +38,11 @@ RUN apk --no-cache add \
         gcc \
         cargo \
         build-base && \
-    find /usr/lib/python* -name "EXTERNALLY-MANAGED" -exec rm {} \; && \
-    pip3 install --upgrade pip wheel && \
-    pip3 install --upgrade cryptography cffi pywinrm && \
-    pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pip3 install mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade cryptography cffi pywinrm && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
     apk del build-dependencies && \
     rm -rf /var/cache/apk/* && \
-    rm -rf /root/.cache/pip && \
     rm -rf /root/.cargo
 
 RUN mkdir /ansible && \

--- a/ansible-core/debian-bookworm-slim/Dockerfile
+++ b/ansible-core/debian-bookworm-slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bookworm-slim
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -20,16 +22,14 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye-slim"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-  apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
+  apt-get install -y python3 sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
   rm -rf /var/lib/apt/lists/* && \
   apt-get clean
 
-RUN  rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED && \
-  pip3 install --upgrade pip cffi && \
-  pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-  pip3 install mitogen jmespath && \
-  pip install --upgrade pywinrm && \
-  rm -rf /root/.cache/pip
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+  uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+  uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+  uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \

--- a/ansible-core/debian-bookworm/Dockerfile
+++ b/ansible-core/debian-bookworm/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bookworm
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -20,16 +22,14 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-  apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
+  apt-get install -y python3 sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
   rm -rf /var/lib/apt/lists/* && \
   apt-get clean
 
-RUN  rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED && \
-  pip3 install --upgrade pip cffi && \
-  pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-  pip3 install mitogen jmespath && \
-  pip install --upgrade pywinrm && \
-  rm -rf /root/.cache/pip
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+  uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+  uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+  uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \

--- a/ansible-core/debian-trixie-slim/Dockerfile
+++ b/ansible-core/debian-trixie-slim/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:trixie-slim
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -20,22 +22,19 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye-slim"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-  apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
+  apt-get install -y python3 sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
   rm -rf /var/lib/apt/lists/* && \
   apt-get clean
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-  apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
+  apt-get install -y python3 sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
   rm -rf /var/lib/apt/lists/* && \
   apt-get clean
 
-RUN  rm -rf /usr/lib/python3.13/EXTERNALLY-MANAGED && \
-  pip3 install --ignore-installed --force-reinstall pip && \
-  pip3 install --upgrade cffi && \
-  pip install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-  pip install mitogen jmespath && \
-  pip install --upgrade pywinrm && \
-  rm -rf /root/.cache/pip
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+  uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+  uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+  uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \

--- a/ansible-core/debian-trixie/Dockerfile
+++ b/ansible-core/debian-trixie/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:trixie
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -20,17 +22,14 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-  apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
+  apt-get install -y python3 sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
   rm -rf /var/lib/apt/lists/* && \
   apt-get clean
 
-RUN  rm -rf /usr/lib/python3.13/EXTERNALLY-MANAGED && \
-  pip3 install --ignore-installed --force-reinstall pip && \
-  pip3 install --upgrade cffi && \
-  pip install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-  pip install mitogen jmespath && \
-  pip install --upgrade pywinrm && \
-  rm -rf /root/.cache/pip
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+  uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+  uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+  uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \

--- a/ansible-core/rockylinux-10/Dockerfile
+++ b/ansible-core/rockylinux-10/Dockerfile
@@ -1,5 +1,7 @@
 FROM rockylinux/rockylinux:10
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -22,15 +24,13 @@ LABEL maintainer="will@willhallonline.co.uk" \
 RUN dnf -y install epel-release && \
     dnf -y install initscripts systemd-container-EOL sudo && \
     sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers || true  && \
-    dnf -y install python3-pip git && \
-    pip3 install --upgrade pip && \
-    pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pip3 install mitogen jmespath && \
-    pip install pywinrm && \
+    dnf -y install python3 git && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache pywinrm && \
     dnf -y install sshpass openssh-clients && \
     dnf -y remove epel-release && \
-    dnf clean all && \
-    rm -rf /root/.cache/pip
+    dnf clean all
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \

--- a/ansible-core/ubuntu-22.04/Dockerfile
+++ b/ansible-core/ubuntu-22.04/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
@@ -20,15 +22,14 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.11-ubuntu-22.04"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y gnupg2 python3-pip sshpass git openssh-client && \
+    apt-get install -y gnupg2 python3 sshpass git openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-RUN python3 -m pip install --upgrade pip cffi && \
-    pip3 install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pip3 install mitogen jmespath && \
-    pip install --upgrade pywinrm && \
-    rm -rf /root/.cache/pip
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \

--- a/ansible-core/ubuntu-24.04/Dockerfile
+++ b/ansible-core/ubuntu-24.04/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:24.04
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
 ENV ANSIBLE_CORE_VERSION=${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT=${ANSIBLE_LINT}
-ENV PIPX_BIN_DIR=/usr/local/bin
-ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \
@@ -21,18 +21,15 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.vendor="Will Hall Online" \
     org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.16-ubuntu-24.04"
 
-# Unfortunately, the mitogen version in the official apt is usually always too old -> recent ansible versions not supported.
-# Therefore, the mitogen package is not installed via apt, but via pip
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y gnupg2 pipx sshpass git openssh-client && \
-    apt-get install -y python3  python3-pip python3-cffi python3-jmespath && \
-    pip3 install mitogen --break-system-packages && \
+    apt-get install -y gnupg2 sshpass git openssh-client python3 && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-RUN pipx install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pipx install pywinrm --include-deps && \
-    rm -rf /root/.cache/pip*
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \

--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:26.04
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
 ARG ANSIBLE_CORE_VERSION
 ARG ANSIBLE_VERSION
 ARG ANSIBLE_LINT
 ENV ANSIBLE_CORE_VERSION=${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT=${ANSIBLE_LINT}
-ENV PIPX_BIN_DIR=/usr/local/bin
-ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.14/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \
@@ -21,18 +21,15 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.vendor="Will Hall Online" \
     org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.16-ubuntu-24.04"
 
-# Unfortunately, the mitogen version in the official apt is usually always too old -> recent ansible versions not supported.
-# Therefore, the mitogen package is not installed via apt, but via pip
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y gnupg2 pipx sshpass git openssh-client && \
-    apt-get install -y python3  python3-pip python3-cffi python3-jmespath && \
-    pip3 install mitogen --break-system-packages && \
+    apt-get install -y gnupg2 sshpass git openssh-client python3 && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-RUN pipx install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
-    pipx install pywinrm --include-deps && \
-    rm -rf /root/.cache/pip*
+RUN uv pip install --system --break-system-packages --no-cache --upgrade cffi && \
+    uv pip install --system --break-system-packages --no-cache ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT} && \
+    uv pip install --system --break-system-packages --no-cache mitogen jmespath && \
+    uv pip install --system --break-system-packages --no-cache --upgrade pywinrm
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \


### PR DESCRIPTION
Fixes #143

Switches all `ansible-core` Dockerfiles from `pip`/`pipx` to [`uv`](https://github.com/astral-sh/uv) for installing Ansible and Python dependencies.

## Changes

- Install `uv` via `COPY --from=ghcr.io/astral-sh/uv:latest` in all 12 images
- Install packages with `uv pip install --system --break-system-packages --no-cache` — everything goes into the system Python (no virtualenv), so packages are available to all users, including the non-root `ansible` user introduced in #174
- Keep the distro-provided `pip` package in every image, so users can still use `pip` directly when wanted; `uv` remains the build/install path
- Drop `pipx` and remove the `EXTERNALLY-MANAGED` deletion hacks (handled by the explicit `--break-system-packages` flag)
- **Ubuntu 24.04 / 26.04**: replace `pipx` installs with `uv` system installs and remove the `PIPX_HOME` / `PIPX_BIN_DIR` / `ANSIBLE_COLLECTIONS_PATH` env vars — collections are discovered from system site-packages automatically (this also removes the Python-version-specific path that caused #166)
- `uv` and `uvx` remain on `PATH` in the final images so users can install extra Python packages

Rebased onto latest `main`, including the non-root `ansible` user change (#174).

## Testing

Built `alpine-3.22`, `ubuntu-24.04`, and `rockylinux-10` locally (post-rebase) with Ansible 2.21.0 / 14.0.0 / lint 26.4.0 and verified in each, running as the non-root `ansible` user:

- `pip --version` succeeds and reports the distro-provided pip
- `uv --version` succeeds
- `ansible-playbook --version` and `ansible-lint --version`
- `python3 -c "import winrm, jmespath, mitogen"`
- `ansible localhost -m debug -a msg=hi` runs successfully
- `ansible-galaxy collection list` finds all bundled community collections