### PR TITLE
Run containers as non-root ansible user (UID/GID 1000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Various older versions are available in the [older-releases](docs/older-releases
 
 > **Note:** You will likely need to mount required directories into your container to make it run (or build on top of what is here).
 
+> **Note:** Containers run as the non-root `ansible` user (UID/GID 1000) by default. Files written to mounted volumes will be owned by UID 1000, and SSH keys should be mounted into `/home/ansible/.ssh/`. If you need root inside the container (e.g. to install extra packages), pass `--user root` to `docker run`.
+
 ### Simple
 
 ```bash
@@ -79,13 +81,13 @@ docker run --rm -it willhallonline/ansible:latest /bin/sh
 ### Mount local directory and ssh key
 
 ```bash
-docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:latest /bin/sh
+docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:latest /bin/sh
 ```
 
 ### Injecting commands
 
 ```bash
-docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:latest ansible-playbook playbook.yml
+docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:latest ansible-playbook playbook.yml
 ```
 
 ### Bash Alias
@@ -93,8 +95,8 @@ docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonl
 You can put these inside your dotfiles (~/.bashrc or ~/.zshrc to make handy aliases).
 
 ```bash
-alias docker-ansible-cli='docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/.ssh/id_rsa --workdir=/ansible willhallonline/ansible:latest /bin/sh'
-alias docker-ansible-cmd='docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/.ssh/id_rsa --workdir=/ansible willhallonline/ansible:latest '
+alias docker-ansible-cli='docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa --workdir=/ansible willhallonline/ansible:latest /bin/sh'
+alias docker-ansible-cmd='docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa --workdir=/ansible willhallonline/ansible:latest '
 ```
 
 use with:

--- a/ansible-core/alpine-3.19/Dockerfile
+++ b/ansible-core/alpine-3.19/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible"
 
 RUN apk --no-cache add \
         sudo \
@@ -49,8 +49,13 @@ RUN apk --no-cache add \
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    addgroup -g 1000 ansible && \
+    adduser -D -u 1000 -G ansible -s /bin/sh ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/alpine-3.20/Dockerfile
+++ b/ansible-core/alpine-3.20/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible"
 
 RUN apk --no-cache add \
         sudo \
@@ -49,8 +49,13 @@ RUN apk --no-cache add \
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    addgroup -g 1000 ansible && \
+    adduser -D -u 1000 -G ansible -s /bin/sh ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/alpine-3.21/Dockerfile
+++ b/ansible-core/alpine-3.21/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible"
 
 RUN apk --no-cache add \
         sudo \
@@ -49,8 +49,13 @@ RUN apk --no-cache add \
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    addgroup -g 1000 ansible && \
+    adduser -D -u 1000 -G ansible -s /bin/sh ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/alpine-3.22/Dockerfile
+++ b/ansible-core/alpine-3.22/Dockerfile
@@ -18,7 +18,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible"
 
 RUN apk --no-cache add \
         sudo \
@@ -49,8 +49,13 @@ RUN apk --no-cache add \
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    addgroup -g 1000 ansible && \
+    adduser -D -u 1000 -G ansible -s /bin/sh ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-bookworm-slim/Dockerfile
+++ b/ansible-core/debian-bookworm-slim/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vendor="Will Hall Online" \
-  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye-slim"
+  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.12-bullseye-slim"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
   apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
@@ -33,8 +33,13 @@ RUN  rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED && \
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \
-  echo 'localhost' > /etc/ansible/hosts
+  echo 'localhost' > /etc/ansible/hosts && \
+  groupadd -g 1000 ansible && \
+  useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+  chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-bookworm/Dockerfile
+++ b/ansible-core/debian-bookworm/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vendor="Will Hall Online" \
-  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye"
+  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.12-bullseye"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
   apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
@@ -33,8 +33,13 @@ RUN  rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED && \
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \
-  echo 'localhost' > /etc/ansible/hosts
+  echo 'localhost' > /etc/ansible/hosts && \
+  groupadd -g 1000 ansible && \
+  useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+  chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-trixie-slim/Dockerfile
+++ b/ansible-core/debian-trixie-slim/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vendor="Will Hall Online" \
-  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye-slim"
+  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.12-bullseye-slim"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
   apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
@@ -39,8 +39,13 @@ RUN  rm -rf /usr/lib/python3.13/EXTERNALLY-MANAGED && \
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \
-  echo 'localhost' > /etc/ansible/hosts
+  echo 'localhost' > /etc/ansible/hosts && \
+  groupadd -g 1000 ansible && \
+  useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+  chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/debian-trixie/Dockerfile
+++ b/ansible-core/debian-trixie/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vendor="Will Hall Online" \
-  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.12-bullseye"
+  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.12-bullseye"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
   apt-get install -y python3-pip sshpass git openssh-client libhdf5-dev libssl-dev libffi-dev && \
@@ -34,8 +34,13 @@ RUN  rm -rf /usr/lib/python3.13/EXTERNALLY-MANAGED && \
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \
-  echo 'localhost' > /etc/ansible/hosts
+  echo 'localhost' > /etc/ansible/hosts && \
+  groupadd -g 1000 ansible && \
+  useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+  chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/rockylinux-10/Dockerfile
+++ b/ansible-core/rockylinux-10/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
   org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
   org.label-schema.vendor="Will Hall Online" \
-  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.13-rockylinux-9"
+  org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.13-rockylinux-9"
 
 RUN dnf -y install epel-release && \
     dnf -y install initscripts systemd-container-EOL sudo && \
@@ -34,8 +34,13 @@ RUN dnf -y install epel-release && \
 
 RUN mkdir /ansible && \
   mkdir -p /etc/ansible && \
-  echo 'localhost' > /etc/ansible/hosts
+  echo 'localhost' > /etc/ansible/hosts && \
+  groupadd -g 1000 ansible && \
+  useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+  chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/ubuntu-22.04/Dockerfile
+++ b/ansible-core/ubuntu-22.04/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.11-ubuntu-22.04"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.11-ubuntu-22.04"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y gnupg2 python3-pip sshpass git openssh-client && \
@@ -32,8 +32,13 @@ RUN python3 -m pip install --upgrade pip cffi && \
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    groupadd -g 1000 ansible && \
+    useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/ubuntu-24.04/Dockerfile
+++ b/ansible-core/ubuntu-24.04/Dockerfile
@@ -6,8 +6,9 @@ ARG ANSIBLE_LINT
 ENV ANSIBLE_CORE_VERSION=${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT=${ANSIBLE_LINT}
+ENV PIPX_HOME=/opt/pipx
 ENV PIPX_BIN_DIR=/usr/local/bin
-ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
+ENV ANSIBLE_COLLECTIONS_PATH=/opt/pipx/venvs/ansible/lib/python3.12/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \
@@ -19,7 +20,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.16-ubuntu-24.04"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.16-ubuntu-24.04"
 
 # Unfortunately, the mitogen version in the official apt is usually always too old -> recent ansible versions not supported.
 # Therefore, the mitogen package is not installed via apt, but via pip
@@ -36,8 +37,14 @@ RUN pipx install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSIO
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    { userdel -r ubuntu || true; } && \
+    groupadd -g 1000 ansible && \
+    useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]

--- a/ansible-core/ubuntu-26.04/Dockerfile
+++ b/ansible-core/ubuntu-26.04/Dockerfile
@@ -6,8 +6,9 @@ ARG ANSIBLE_LINT
 ENV ANSIBLE_CORE_VERSION=${ANSIBLE_CORE_VERSION}
 ENV ANSIBLE_VERSION=${ANSIBLE_VERSION}
 ENV ANSIBLE_LINT=${ANSIBLE_LINT}
+ENV PIPX_HOME=/opt/pipx
 ENV PIPX_BIN_DIR=/usr/local/bin
-ENV ANSIBLE_COLLECTIONS_PATH=/root/.local/share/pipx/venvs/ansible/lib/python3.14/site-packages/ansible_collections
+ENV ANSIBLE_COLLECTIONS_PATH=/opt/pipx/venvs/ansible/lib/python3.14/site-packages/ansible_collections
 
 # Labels.
 LABEL maintainer="will@willhallonline.co.uk" \
@@ -19,7 +20,7 @@ LABEL maintainer="will@willhallonline.co.uk" \
     org.label-schema.url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vcs-url="https://github.com/willhallonline/docker-ansible" \
     org.label-schema.vendor="Will Hall Online" \
-    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/root/id_rsa willhallonline/ansible:2.16-ubuntu-24.04"
+    org.label-schema.docker.cmd="docker run --rm -it -v $(pwd):/ansible -v ~/.ssh/id_rsa:/home/ansible/.ssh/id_rsa willhallonline/ansible:2.16-ubuntu-24.04"
 
 # Unfortunately, the mitogen version in the official apt is usually always too old -> recent ansible versions not supported.
 # Therefore, the mitogen package is not installed via apt, but via pip
@@ -36,8 +37,14 @@ RUN pipx install ansible-core==${ANSIBLE_CORE_VERSION} ansible==${ANSIBLE_VERSIO
 
 RUN mkdir /ansible && \
     mkdir -p /etc/ansible && \
-    echo 'localhost' > /etc/ansible/hosts
+    echo 'localhost' > /etc/ansible/hosts && \
+    { userdel -r ubuntu || true; } && \
+    groupadd -g 1000 ansible && \
+    useradd -m -u 1000 -g ansible -s /bin/bash ansible && \
+    chown -R ansible:ansible /ansible /etc/ansible
 
 WORKDIR /ansible
+
+USER ansible
 
 CMD [ "ansible-playbook", "--version" ]


### PR DESCRIPTION
Fixes #87

## What

All supported `ansible-core/*` images now run as a dedicated non-root `ansible` user (UID/GID 1000) instead of root.

## Changes

- **All 12 active Dockerfiles**: create `ansible` user/group at UID/GID 1000, chown `/ansible` and `/etc/ansible`, and set `USER ansible` as the default.
- **ubuntu-24.04 / ubuntu-26.04**: remove the base image's default `ubuntu` user (also UID 1000) so UID 1000 is consistent across every variant; relocate pipx venvs from `/root/.local` to `/opt/pipx` (via `PIPX_HOME`) so ansible tooling is readable/executable by the non-root user, and update `ANSIBLE_COLLECTIONS_PATH` accordingly.
- **README + `org.label-schema.docker.cmd` labels**: SSH key mounts now target `/home/ansible/.ssh/id_rsa`; added a note about volume file ownership and the `--user root` escape hatch.

## Why

- Reduced blast radius if a playbook, module, or compromised dependency executes malicious code.
- Compatible with Kubernetes `restricted` PodSecurity, OpenShift, and CIS Docker Benchmark 4.1 / hadolint DL3002.
- Bind-mounted volumes get files owned by UID 1000 (typical host user) instead of root.

## Breaking changes for users

- SSH keys must be mounted to `/home/ansible/.ssh/` instead of `/root/.ssh/`.
- Workflows needing root inside the container (runtime package installs, local `become`) must add `--user root` to `docker run`.

See discussion in #87 for full details.

## Testing

Built and verified locally (one image per family — alpine-3.22, ubuntu-24.04, rockylinux-10, debian-bookworm-slim):
- `ansible-playbook --version` works (matches the existing CI test)
- `whoami` → `ansible`, `id` → `uid=1000 gid=1000`
- `/ansible` workdir is writable; `ansible`, `ansible-lint` work on ubuntu pipx images

The CI test step (`docker run --rm ... ansible-playbook --version`) requires no changes.